### PR TITLE
Refactor: simplify logic

### DIFF
--- a/muxify.go
+++ b/muxify.go
@@ -87,10 +87,12 @@ func (mux *Mux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // Subrouter returns a sub mux.
 func (mux *Mux) Subrouter() *Mux {
-	subMux := &Mux{muxify: mux.muxify, patternPrefix: mux.patternPrefix}
-	subMux.middlewares = append(subMux.middlewares, mux.middlewares...)
-	subMux.registeredPatterns = mux.registeredPatterns
-	return subMux
+	return &Mux{
+		muxify:             mux.muxify,
+		patternPrefix:      mux.patternPrefix,
+		middlewares:        mux.middlewares,
+		registeredPatterns: mux.registeredPatterns,
+	}
 }
 
 // Use wraps a middleware to the mux.

--- a/muxify.go
+++ b/muxify.go
@@ -2,49 +2,32 @@
 //
 // The muxify package is a default serve mux builder.
 // Build patterns, handlers and wrap middlewares conveniently upfront.
-// The muxify.ServeMuxBuilder acts as a builder for the http.ServeMux.
+// The muxify.Mux acts as a builder for the http.ServeMux.
 // The overall goal of this package is to build the http.ServeMux with pattern/path prefixes and middleware wired in.
 package muxify
 
 import (
-	"fmt"
 	"net/http"
 	"regexp"
 	"strings"
 )
 
-// ServeMuxBuilder is a simple builder for the http.ServeMux.
-type ServeMuxBuilder struct {
-	// Patterns represent the given patterns to http.Handle/http.HandleFunc.
-	Patterns map[string]http.Handler
-	// PatternPrefix represent the prefix of the pattern of a subrouter.
-	PatternPrefix string
-	// Middlewares represent the middlewares that wrap the subrouter.
-	Middlewares []Middleware
-	// Root always points to the root node of the default servce mux builder.
-	Root *ServeMuxBuilder
-	// Parent always points to the parent node.
-	// For the root field the parent would also be root.
-	Parent *ServeMuxBuilder
-
-	// SubServeMuxBuilder stores the subrouters of the main router.
-	SubServeMuxBuilder []*ServeMuxBuilder
-
-	// executedBuild is used to track if the Build() function has been executed.
-	executedBuild bool
-	// registeredPatterns stores the patterns that have been registered to the default serve mux.
-	registeredPatterns []string
+// Mux is a simple wrapper for the http.ServeMux.
+type Mux struct {
+	muxify        *http.ServeMux
+	patternPrefix string
+	middlewares   []Middleware
 }
 
 // Middleware represents an http.Handler wrapper to inject addional functionality.
 type Middleware func(http.Handler) http.Handler
 
-// NewServeMuxBuilder returns a new ServeMuxBuilder.
-func NewServeMuxBuilder() *ServeMuxBuilder {
-	b := &ServeMuxBuilder{Patterns: map[string]http.Handler{}}
-	b.Root = b
-	b.Parent = b
-	return b
+// NewMux returns a new muxify.Mux.
+// This is a simple wrapper for the http.ServeMux.
+func NewMux() *Mux {
+	return &Mux{
+		muxify: http.NewServeMux(),
+	}
 }
 
 // newHandler returns an http.Handler wrapped with given middlewares.
@@ -57,38 +40,43 @@ func newHandler(mw ...Middleware) func(http.Handler) http.Handler {
 	}
 }
 
-// Pattern registers hanglers for given patterns.
-func (b *ServeMuxBuilder) Pattern(patterns map[string]http.Handler) {
-	patternPrefix := b.PatternPrefix
-	b.PatternPrefix = ""
-	b.PatternPrefix = b.Root.PatternPrefix
+// splitPattern helps splitting the pattern "GET /a/b"
+// more specifically the method from the path and
+// returns both as a string.
+func splitPattern(pattern string) (method string, patternPath string) {
+	splitPattern := strings.Split(pattern, " ")
 
-	for _, subBuilder := range b.Parent.SubServeMuxBuilder {
-		if b.Parent != b.Root {
-			for _, subSubBuilder := range subBuilder.SubServeMuxBuilder {
-				b.PatternPrefix = subSubBuilder.PatternPrefix
-			}
-		}
+	switch len(splitPattern) {
+	case 2:
+		method = splitPattern[0] + " "
+		patternPath = splitPattern[1]
+	default:
+		patternPath = splitPattern[0]
 	}
 
-	b.PatternPrefix += patternPrefix
+	return method, patternPath
+}
 
-	for pattern, handler := range patterns {
-		tmpPattern := strings.Split(pattern, " ")
+// HandleFunc wraps the http.HandleFunc func.
+// It wraps the pattern with prefixes
+// and the handler with middlewares.
+func (mux *Mux) HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request)) {
+	method, patternPath := splitPattern(pattern)
+	mux.muxify.Handle(
+		method+removeDoubleSlash(mux.patternPrefix+patternPath),
+		newHandler(mux.middlewares...)(http.HandlerFunc(handler)),
+	)
+}
 
-		var method string
-		var patternPath string
-		switch len(tmpPattern) {
-		case 2:
-			method = tmpPattern[0] + " "
-			patternPath = tmpPattern[1]
-		default:
-			patternPath = tmpPattern[0]
-		}
-
-		b.Patterns[method+removeDoubleSlash(b.PatternPrefix+patternPath)] = handler
-	}
-	b.SubServeMuxBuilder = append(b.SubServeMuxBuilder, b)
+// Handle wraps the http.Handle func.
+// It wraps the pattern with prefixes
+// and the handler with middlewares.
+func (mux *Mux) Handle(pattern string, handler http.Handler) {
+	method, patternPath := splitPattern(pattern)
+	mux.muxify.Handle(
+		method+removeDoubleSlash(mux.patternPrefix+patternPath),
+		newHandler(mux.middlewares...)(handler),
+	)
 }
 
 func removeDoubleSlash(text string) string {
@@ -96,77 +84,31 @@ func removeDoubleSlash(text string) string {
 	return re.ReplaceAllString(text, "/")
 }
 
-// Use wraps a middleware to an ServeMuxBuilder.
-func (b *ServeMuxBuilder) Use(middleware ...Middleware) {
-	b.Middlewares = append(b.Middlewares, middleware...)
+// Use wraps a middleware to the mux.
+func (mux *Mux) Use(middleware ...Middleware) {
+	mux.middlewares = append(mux.middlewares, middleware...)
 }
 
-// Prefix sets a prefix for the ServeMuxBuilder.
-func (b *ServeMuxBuilder) Prefix(prefix string) {
+// Prefix sets a prefix for the mux.
+func (mux *Mux) Prefix(prefix string) *Mux {
 	if len(prefix) > 0 {
 		if prefix[0] != '/' {
 			prefix = "/" + prefix
 		}
 	}
 
-	b.PatternPrefix = prefix
+	mux.patternPrefix += prefix
+	return mux
 }
 
-// Subrouter returns an ServeMuxBuilder child.
-func (b *ServeMuxBuilder) Subrouter() *ServeMuxBuilder {
-	subBuilder := NewServeMuxBuilder()
-	subBuilder.Parent = b
-	subBuilder.Root = b.Root
-
-	if subBuilder.Parent != b.Root {
-		subBuilder.Middlewares = append(subBuilder.Middlewares, subBuilder.Parent.Middlewares...)
-	} else {
-		subBuilder.Middlewares = append(subBuilder.Middlewares, b.Root.Middlewares...)
-	}
-
-	b.SubServeMuxBuilder = append(b.SubServeMuxBuilder, subBuilder)
-
-	return subBuilder
+// Subrouter returns a sub mux.
+func (mux *Mux) Subrouter() *Mux {
+	subMux := &Mux{muxify: mux.muxify, patternPrefix: mux.patternPrefix}
+	subMux.middlewares = append(subMux.middlewares, mux.middlewares...)
+	return subMux
 }
 
-// PrintRegisteredPatterns prints the registered patterns of the http.ServeMux.
-// The Build() method needs to be called before!
-func (b *ServeMuxBuilder) PrintRegisteredPatterns() {
-	if b.Root.executedBuild {
-		fmt.Println("* Registered patterns:", strings.Repeat("*", 47))
-		fmt.Println(strings.Join(b.Root.registeredPatterns, "\n"))
-		fmt.Printf("%s\n\n", strings.Repeat("*", 70))
-	}
-}
-
-// Build constructs an http.ServeMux with the patterns, handlers and middlewares
-// from the ServeMuxBuilder.
-//
-// Always builds from root ServeMuxBuilder node.
-func (b *ServeMuxBuilder) Build() *http.ServeMux {
-	defaultServeMux := http.ServeMux{}
-	queue := []*ServeMuxBuilder{b.Root}
-	visited := make(map[*ServeMuxBuilder]bool)
-
-	for len(queue) > 0 {
-		current := queue[0]
-		queue = queue[1:]
-
-		if visited[current] {
-			continue
-		}
-		visited[current] = true
-
-		if current.Patterns != nil {
-			for pattern, handler := range current.Patterns {
-				b.Root.registeredPatterns = append(b.Root.registeredPatterns, pattern)
-				defaultServeMux.Handle(pattern, newHandler(current.Middlewares...)(handler))
-			}
-		}
-
-		queue = append(queue, current.SubServeMuxBuilder...)
-	}
-
-	b.Root.executedBuild = true
-	return &defaultServeMux
+// Implement http.Handler interface.
+func (mux *Mux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	mux.muxify.ServeHTTP(w, r)
 }

--- a/muxify.go
+++ b/muxify.go
@@ -50,12 +50,12 @@ func (mux *Mux) Handle(pattern string, handler http.Handler) {
 // HandleFunc wraps the http.HandleFunc func.
 // It wraps the pattern with prefixes
 // and the handler with middlewares.
-func (mux *Mux) HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request)) {
+func (mux *Mux) HandleFunc(pattern string, handlerFunc func(http.ResponseWriter, *http.Request)) {
 	method, patternPath := splitPattern(pattern)
 	pattern = method + removeDoubleSlash(mux.patternPrefix+patternPath)
 	mux.muxify.Handle(
 		pattern,
-		newHandler(mux.middlewares...)(http.HandlerFunc(handler)),
+		newHandler(mux.middlewares...)(http.HandlerFunc(handlerFunc)),
 	)
 	*mux.registeredPatterns = append(*mux.registeredPatterns, pattern)
 }

--- a/muxify_internal_test.go
+++ b/muxify_internal_test.go
@@ -109,3 +109,38 @@ func Test_removeDoubleSlash(t *testing.T) {
 		})
 	}
 }
+
+func Test_Prefix(t *testing.T) {
+	testCases := map[string]struct {
+		prefix string
+	}{
+		"ok - no slash prefix": {
+			prefix: "a",
+		},
+		"ok - slash prefix": {
+			prefix: "/a",
+		},
+		"ok - empty": {
+			prefix: "//a",
+		},
+	}
+	for tname, tc := range testCases {
+		t.Run(tname, func(t *testing.T) {
+			mux := Mux{}
+
+			mux.Prefix(tc.prefix)
+
+			got := mux.patternPrefix
+
+			if len(tc.prefix) > 0 {
+				if tc.prefix[0] != '/' {
+					tc.prefix = "/" + tc.prefix
+				}
+			}
+
+			if got != tc.prefix {
+				t.Errorf("\nwant: %v\ngot: %v\n", tc.prefix, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Refactor the generation of the http.ServeMux completely.

This leads to alot faster generation of the serve mux 🥳.