### PR TITLE
set compatible go versions in githubci

### DIFF
--- a/.github/workflows/test-ubuntu-macos.yaml
+++ b/.github/workflows/test-ubuntu-macos.yaml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go-version: [1, 1.18, 1.22, 1.23]
+        go-version: [1, 1.18, 1.21, 1.22, 1.23]
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v4
@@ -30,4 +30,3 @@ jobs:
         run: |
           go install golang.org/x/lint/golint@latest
           golint ./...
-

--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -5,7 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1, 1.18, 1.22, 1.23]
+        go-version: [1, 1.18, 1.21, 1.22, 1.23]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
* Keep `go1` for fun, lets see how long it will take until it breaks
* version `go1.19` and `go1.20` does not work

<img width="464" alt="Screenshot 2025-02-13 at 21 37 18" src="https://github.com/user-attachments/assets/9c3637c3-c9d5-4a0c-a1dc-b08003062196" />
