### PR TITLE
remove `removeDoubleSlash` function (let go compiler handle errors)

### DIFF
--- a/muxify_below_1.22_test.go
+++ b/muxify_below_1.22_test.go
@@ -43,12 +43,6 @@ func Test_Bootstrap_below_122(t *testing.T) {
 			expBody:       "POST",
 			expStatusCode: http.StatusOK,
 		},
-		"get with id (test remove double slashes)": {
-			path:          "/a/b/e/d/f",
-			method:        http.MethodDelete,
-			expBody:       "DELETE",
-			expStatusCode: http.StatusOK,
-		},
 		"notfound /": {
 			path:          "/",
 			method:        http.MethodGet,
@@ -65,6 +59,12 @@ func Test_Bootstrap_below_122(t *testing.T) {
 			path:          "/oldschool",
 			expBody:       "oldschool",
 			expStatusCode: http.StatusOK,
+		},
+		"no panic but also no route registered": {
+			path:          "/a/b/e/d/f",
+			method:        http.MethodDelete,
+			expBody:       "not found",
+			expStatusCode: http.StatusNotFound,
 		},
 	}
 	for tname, tc := range testCases {
@@ -98,9 +98,7 @@ func Test_Bootstrap_below_122(t *testing.T) {
 			subMux.HandleFunc("/e", func(w http.ResponseWriter, r *http.Request) {
 				_, _ = w.Write([]byte("POST"))
 			})
-			subMux.HandleFunc("/e/////d///f//", func(w http.ResponseWriter, r *http.Request) {
-				_, _ = w.Write([]byte("DELETE"))
-			})
+			subMux.HandleFunc("/e/////d///f//", func(w http.ResponseWriter, r *http.Request) {})
 
 			server := httptest.NewServer(mux)
 			defer server.Close()

--- a/muxify_internal_test.go
+++ b/muxify_internal_test.go
@@ -86,47 +86,33 @@ func testMiddleware3(next http.Handler) http.Handler {
 	})
 }
 
-func Test_removeDoubleSlash(t *testing.T) {
-	testCases := map[string]struct {
-		text              string
-		expRemovedSlashes string
-	}{
-		"many slashes": {
-			text:              "//a/////////b////c//",
-			expRemovedSlashes: "/a/b/c/",
-		},
-		"slashes in between": {
-			text:              "a///b///c",
-			expRemovedSlashes: "a/b/c",
-		},
-	}
-	for tname, tc := range testCases {
-		t.Run(tname, func(t *testing.T) {
-			removedSlashes := removeDoubleSlash(tc.text)
-			if removedSlashes != tc.expRemovedSlashes {
-				t.Errorf("\nexpected: %v\ngot: %v\n", tc.expRemovedSlashes, removedSlashes)
-			}
-		})
-	}
-}
-
 func Test_Prefix(t *testing.T) {
 	testCases := map[string]struct {
-		prefix string
+		prefix    string
+		expPrefix string
 	}{
 		"ok - no slash prefix": {
-			prefix: "a",
+			prefix:    "a",
+			expPrefix: "/v1/a",
 		},
 		"ok - slash prefix": {
-			prefix: "/a",
+			prefix:    "/a",
+			expPrefix: "/v1/a",
+		},
+		"ok - let go compiler handle": {
+			prefix:    "//a",
+			expPrefix: "/v1//a",
 		},
 		"ok - empty": {
-			prefix: "//a",
+			prefix:    "",
+			expPrefix: "/v1",
 		},
 	}
 	for tname, tc := range testCases {
 		t.Run(tname, func(t *testing.T) {
-			mux := Mux{}
+			mux := Mux{
+				patternPrefix: "/v1",
+			}
 
 			mux.Prefix(tc.prefix)
 
@@ -138,8 +124,8 @@ func Test_Prefix(t *testing.T) {
 				}
 			}
 
-			if got != tc.prefix {
-				t.Errorf("\nwant: %v\ngot: %v\n", tc.prefix, got)
+			if got != tc.expPrefix {
+				t.Errorf("\nwant: %v\ngot: %v\n", tc.expPrefix, got)
 			}
 		})
 	}


### PR DESCRIPTION
Removing the functionality to handle typos or similar that lead to double slashes in the pattern like `/a//b`. The go compiler will panic if the patter is in the new style (`go1.22`) of `GET /a//b` and the old style will not register a route (ignore it) `/a//b`.

Tests for this behavior of go have been added.

* Order of function in muxify
* Delete tests of `removeDoubleSlash`